### PR TITLE
feat: redirect local auth straight to dbxstudio.com

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -69,7 +69,29 @@ export default function App() {
 }
 
 function AuthenticatedApp() {
-    const { isAuthenticated, isLoading, logout } = useAuth()
+    const { isAuthenticated, isLoading, logout, token, user } = useAuth()
+
+    // Handle immediate redirect for already-authenticated users
+    useEffect(() => {
+        if (isAuthenticated && token && user) {
+            const searchParams = new URLSearchParams(window.location.search);
+            const redirectUrl = searchParams.get('redirect');
+            if (redirectUrl) {
+                try {
+                    const targetUrl = new URL(redirectUrl);
+                    targetUrl.searchParams.set('token', token);
+                    targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(user)));
+
+                    const refreshToken = localStorage.getItem('dbx_refresh_token');
+                    if (refreshToken) targetUrl.searchParams.set('refreshToken', refreshToken);
+
+                    window.location.href = targetUrl.toString();
+                } catch (e) {
+                    console.error("Invalid redirect URL", e);
+                }
+            }
+        }
+    }, [isAuthenticated, token, user]);
 
     // Show loading while checking auth
     if (isLoading) {

--- a/apps/desktop/src/features/auth/components/Login/index.tsx
+++ b/apps/desktop/src/features/auth/components/Login/index.tsx
@@ -54,6 +54,22 @@ export function Login({ onSuccess }: LoginProps) {
     const [authLoadingMessage, setAuthLoadingMessage] = useState('Authenticating...')
     const [useCognito, setUseCognito] = useState(true) // Use Cognito by default
 
+    // Redirect local users to main site for authentication
+    useEffect(() => {
+        const hostname = window.location.hostname;
+        const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+        const searchParams = new URLSearchParams(window.location.search);
+
+        // Skip redirect if we're rendering to handle a returned token
+        const hasToken = searchParams.has('token');
+
+        if (isLocal && !hasToken) {
+            const targetParams = new URLSearchParams();
+            targetParams.set('redirect', window.location.origin);
+            window.location.href = `https://www.dbxstudio.com/login?${targetParams.toString()}`;
+        }
+    }, []);
+
     // Clear errors after timeout
     useEffect(() => {
         if (errorMessage) {
@@ -137,7 +153,19 @@ export function Login({ onSuccess }: LoginProps) {
                     localStorage.setItem('dbx_user_info', JSON.stringify(syncResult.user))
 
                     setLoginSuccess(true)
-                    setTimeout(() => window.location.reload(), 1500)
+                    setTimeout(() => {
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const redirectUrl = urlParams.get('redirect');
+                        if (redirectUrl) {
+                            const targetUrl = new URL(redirectUrl);
+                            targetUrl.searchParams.set('token', signInResult.token!);
+                            targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(syncResult.user)));
+                            if (signInResult.refreshToken) targetUrl.searchParams.set('refreshToken', signInResult.refreshToken);
+                            window.location.href = targetUrl.toString();
+                        } else {
+                            window.location.reload();
+                        }
+                    }, 1500)
                 }
             }
         } catch (error) {
@@ -174,7 +202,19 @@ export function Login({ onSuccess }: LoginProps) {
                     localStorage.setItem('dbx_user_info', JSON.stringify(syncResult.user))
 
                     setLoginSuccess(true)
-                    setTimeout(() => window.location.reload(), 1500)
+                    setTimeout(() => {
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const redirectUrl = urlParams.get('redirect');
+                        if (redirectUrl) {
+                            const targetUrl = new URL(redirectUrl);
+                            targetUrl.searchParams.set('token', result.token!);
+                            targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(syncResult.user)));
+                            if (result.refreshToken) targetUrl.searchParams.set('refreshToken', result.refreshToken);
+                            window.location.href = targetUrl.toString();
+                        } else {
+                            window.location.reload();
+                        }
+                    }, 1500)
                 } else {
                     throw new Error(syncResult.error || 'Backend sync failed')
                 }
@@ -252,7 +292,17 @@ export function Login({ onSuccess }: LoginProps) {
 
             // Trigger success callback
             setTimeout(() => {
-                onSuccess?.()
+                const urlParams = new URLSearchParams(window.location.search);
+                const redirectUrl = urlParams.get('redirect');
+                if (redirectUrl) {
+                    const targetUrl = new URL(redirectUrl);
+                    targetUrl.searchParams.set('token', data.token || token);
+                    targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(userInfo)));
+                    if (refreshToken) targetUrl.searchParams.set('refreshToken', refreshToken);
+                    window.location.href = targetUrl.toString();
+                } else {
+                    onSuccess?.()
+                }
             }, 1500)
 
         } catch (error) {

--- a/apps/desktop/src/features/auth/context/AuthContext.tsx
+++ b/apps/desktop/src/features/auth/context/AuthContext.tsx
@@ -28,6 +28,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Initialize from localStorage using authTokenManager
     useEffect(() => {
+        // Check URL for tokens (if redirected from live site)
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlToken = urlParams.get('token');
+        const urlUser = urlParams.get('user');
+        const urlRefreshToken = urlParams.get('refreshToken');
+
+        if (urlToken && urlUser) {
+            try {
+                const parsedUser = JSON.parse(decodeURIComponent(urlUser));
+                setCustomAuthToken(urlToken, parsedUser, urlRefreshToken || null);
+                setToken(urlToken);
+                setUser(parsedUser);
+                console.log('✅ [AuthContext] User logged in from redirect URL');
+
+                // Cleanup URL
+                window.history.replaceState({}, document.title, window.location.pathname);
+                setIsLoading(false);
+                return;
+            } catch (e) {
+                console.error("❌ [AuthContext] Failed to parse user from redirect URL", e);
+            }
+        }
+
         const storedToken = getAuthToken()
         const storedUser = getUserInfo()
 
@@ -39,20 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setToken(storedToken)
             setUser(storedUser)
         } else {
-            // Auto-login with default guest user (no login required)
-            const defaultToken = 'guest_token_' + Math.random().toString(36).substr(2, 9)
-            const defaultUser: UserInfo = {
-                user_id: 'guest_user',
-                firebase_user_id: 'guest_user',
-                email: 'guest@dbxstudio.local',
-                first_name: 'Guest',
-                last_name: 'User',
-                profile_pic_url: null
-            }
-            setCustomAuthToken(defaultToken, defaultUser, null)
-            setToken(defaultToken)
-            setUser(defaultUser)
-            console.log('✅ [AuthContext] Initialized as guest user (no login required)')
+            console.log('ℹ️ [AuthContext] No valid token found, user needs to login')
         }
 
         setIsLoading(false)

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,7 +69,29 @@ export default function App() {
 }
 
 function AuthenticatedApp() {
-    const { isAuthenticated, isLoading, logout } = useAuth()
+    const { isAuthenticated, isLoading, logout, token, user } = useAuth()
+
+    // Handle immediate redirect for already-authenticated users
+    useEffect(() => {
+        if (isAuthenticated && token && user) {
+            const searchParams = new URLSearchParams(window.location.search);
+            const redirectUrl = searchParams.get('redirect');
+            if (redirectUrl) {
+                try {
+                    const targetUrl = new URL(redirectUrl);
+                    targetUrl.searchParams.set('token', token);
+                    targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(user)));
+
+                    const refreshToken = localStorage.getItem('dbx_refresh_token');
+                    if (refreshToken) targetUrl.searchParams.set('refreshToken', refreshToken);
+
+                    window.location.href = targetUrl.toString();
+                } catch (e) {
+                    console.error("Invalid redirect URL", e);
+                }
+            }
+        }
+    }, [isAuthenticated, token, user]);
 
     // Show loading while checking auth
     if (isLoading) {

--- a/apps/web/src/features/auth/components/Login/index.tsx
+++ b/apps/web/src/features/auth/components/Login/index.tsx
@@ -4,10 +4,10 @@ import { useAuth } from '../../context/AuthContext'
 import { signInWithEmail, signUpWithEmail, signInWithGoogle, sendPasswordResetEmail } from '../../../../shared/utils/firebase'
 import { setCustomAuthToken } from '../../../../shared/utils/authTokenManager'
 import {
-  signUpWithEmail as cognitoSignUp,
-  confirmSignUpWithCode,
-  signInWithEmail as cognitoSignIn,
-  resendVerificationCode,
+    signUpWithEmail as cognitoSignUp,
+    confirmSignUpWithCode,
+    signInWithEmail as cognitoSignIn,
+    resendVerificationCode,
 } from '../../../../shared/utils/cognitoAuth'
 import { syncUserWithBackend } from '../../../../shared/utils/cognitoTokenManager'
 import { VerificationCode } from '../VerificationCode'
@@ -53,6 +53,22 @@ export function Login({ onSuccess }: LoginProps) {
     const [currentView, setCurrentView] = useState<ViewType>('options')
     const [authLoadingMessage, setAuthLoadingMessage] = useState('Authenticating...')
     const [useCognito, setUseCognito] = useState(true) // Use Cognito by default
+
+    // Redirect local users to main site for authentication
+    useEffect(() => {
+        const hostname = window.location.hostname;
+        const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+        const searchParams = new URLSearchParams(window.location.search);
+
+        // Skip redirect if we're rendering to handle a returned token
+        const hasToken = searchParams.has('token');
+
+        if (isLocal && !hasToken) {
+            const targetParams = new URLSearchParams();
+            targetParams.set('redirect', window.location.origin);
+            window.location.href = `https://www.dbxstudio.com/login?${targetParams.toString()}`;
+        }
+    }, []);
 
     // Clear errors after timeout
     useEffect(() => {
@@ -137,7 +153,19 @@ export function Login({ onSuccess }: LoginProps) {
                     localStorage.setItem('dbx_user_info', JSON.stringify(syncResult.user))
 
                     setLoginSuccess(true)
-                    setTimeout(() => window.location.reload(), 1500)
+                    setTimeout(() => {
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const redirectUrl = urlParams.get('redirect');
+                        if (redirectUrl) {
+                            const targetUrl = new URL(redirectUrl);
+                            targetUrl.searchParams.set('token', signInResult.token!);
+                            targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(syncResult.user)));
+                            if (signInResult.refreshToken) targetUrl.searchParams.set('refreshToken', signInResult.refreshToken);
+                            window.location.href = targetUrl.toString();
+                        } else {
+                            window.location.reload();
+                        }
+                    }, 1500)
                 }
             }
         } catch (error) {
@@ -174,7 +202,19 @@ export function Login({ onSuccess }: LoginProps) {
                     localStorage.setItem('dbx_user_info', JSON.stringify(syncResult.user))
 
                     setLoginSuccess(true)
-                    setTimeout(() => window.location.reload(), 1500)
+                    setTimeout(() => {
+                        const urlParams = new URLSearchParams(window.location.search);
+                        const redirectUrl = urlParams.get('redirect');
+                        if (redirectUrl) {
+                            const targetUrl = new URL(redirectUrl);
+                            targetUrl.searchParams.set('token', result.token!);
+                            targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(syncResult.user)));
+                            if (result.refreshToken) targetUrl.searchParams.set('refreshToken', result.refreshToken);
+                            window.location.href = targetUrl.toString();
+                        } else {
+                            window.location.reload();
+                        }
+                    }, 1500)
                 } else {
                     throw new Error(syncResult.error || 'Backend sync failed')
                 }
@@ -252,7 +292,17 @@ export function Login({ onSuccess }: LoginProps) {
 
             // Trigger success callback
             setTimeout(() => {
-                onSuccess?.()
+                const urlParams = new URLSearchParams(window.location.search);
+                const redirectUrl = urlParams.get('redirect');
+                if (redirectUrl) {
+                    const targetUrl = new URL(redirectUrl);
+                    targetUrl.searchParams.set('token', data.token || token);
+                    targetUrl.searchParams.set('user', encodeURIComponent(JSON.stringify(userInfo)));
+                    if (refreshToken) targetUrl.searchParams.set('refreshToken', refreshToken);
+                    window.location.href = targetUrl.toString();
+                } else {
+                    onSuccess?.()
+                }
             }, 1500)
 
         } catch (error) {
@@ -313,7 +363,7 @@ export function Login({ onSuccess }: LoginProps) {
                         if (result.nextStep === 'CONFIRM_SIGN_UP') {
                             setCurrentView('verification')
                             setPendingVerificationEmail(email)
-                            setPendingVerificationUsername(result.username)
+                            setPendingVerificationUsername(result.username ?? null)
                             setPendingUserData(result.user)
                             setPendingPassword(password)
                             setIsAuthenticating(false)

--- a/apps/web/src/features/auth/context/AuthContext.tsx
+++ b/apps/web/src/features/auth/context/AuthContext.tsx
@@ -28,6 +28,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Initialize from localStorage using authTokenManager
     useEffect(() => {
+        // Check URL for tokens (if redirected from live site)
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlToken = urlParams.get('token');
+        const urlUser = urlParams.get('user');
+        const urlRefreshToken = urlParams.get('refreshToken');
+
+        if (urlToken && urlUser) {
+            try {
+                const parsedUser = JSON.parse(decodeURIComponent(urlUser));
+                setCustomAuthToken(urlToken, parsedUser, urlRefreshToken || null);
+                setToken(urlToken);
+                setUser(parsedUser);
+                console.log('✅ [AuthContext] User logged in from redirect URL');
+                
+                // Cleanup URL
+                window.history.replaceState({}, document.title, window.location.pathname);
+                setIsLoading(false);
+                return;
+            } catch (e) {
+                console.error("❌ [AuthContext] Failed to parse user from redirect URL", e);
+            }
+        }
+
         const storedToken = getAuthToken()
         const storedUser = getUserInfo()
 
@@ -41,20 +64,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setToken(storedToken)
             setUser(storedUser)
         } else {
-            // Auto-login with default guest user (no login required)
-            const defaultToken = 'guest_token_' + Math.random().toString(36).substr(2, 9)
-            const defaultUser: UserInfo = {
-                user_id: 'guest_user',
-                firebase_user_id: 'guest_user',
-                email: 'guest@dbxstudio.local',
-                first_name: 'Guest',
-                last_name: 'User',
-                profile_pic_url: null
-            }
-            setCustomAuthToken(defaultToken, defaultUser, null)
-            setToken(defaultToken)
-            setUser(defaultUser)
-            console.log('✅ [AuthContext] Initialized as guest user (no login required)')
+            console.log('ℹ️ [AuthContext] No valid token found, user needs to login')
         }
 
         setIsLoading(false)


### PR DESCRIPTION
### What this does
Bypasses the broken local authentication mock environment. 
When a developer runs the dev environment locally, it will now automatically redirect them to `dbxstudio.com/login` for authentication, and seamlessly bounce them back into their `localhost` environment with their real, authenticated user tokens.
